### PR TITLE
chore: add monorepo skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+*.log
+dist
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # Apollo-Talent-Seeker
-sistema de busca de currículos
+
+Monorepo do sistema de recrutamento baseado em microserviços.
+
+## Estrutura
+
+- `apps/` – aplicações front-end.
+- `services/` – serviços de backend (NestJS).
+
+## Comandos
+
+```bash
+npm test
+```
+
+No momento não há testes implementados.

--- a/apps/admin-ui/Dockerfile
+++ b/apps/admin-ui/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json .
+RUN npm install --production || true
+COPY . .
+CMD ["node", "dist/main.js"]

--- a/apps/admin-ui/README.md
+++ b/apps/admin-ui/README.md
@@ -1,0 +1,3 @@
+# Admin UI
+
+Interface de administração construída em React.

--- a/apps/admin-ui/package.json
+++ b/apps/admin-ui/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@apps/admin-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "echo 'Starting admin UI'",
+    "build": "echo 'Building admin UI'",
+    "test": "echo 'No tests'"
+  }
+}

--- a/apps/admin-ui/src/main.tsx
+++ b/apps/admin-ui/src/main.tsx
@@ -1,0 +1,1 @@
+console.log('Admin UI placeholder');

--- a/apps/admin-ui/tsconfig.json
+++ b/apps/admin-ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/iniciar.bat
+++ b/iniciar.bat
@@ -1,0 +1,46 @@
+@echo off
+
+REM Check Node.js installation
+
+where node >nul 2>&1
+
+IF %ERRORLEVEL% NEQ 0 (
+
+  echo Node.js nao encontrado. Instalando via winget...
+
+  winget install OpenJS.NodeJS -e --id OpenJS.NodeJS -h
+
+  set "PATH=%ProgramFiles%\nodejs;%PATH%"
+
+)
+
+
+
+REM Verify npm availability
+
+npm --version >nul 2>&1
+
+IF %ERRORLEVEL% NEQ 0 (
+
+  echo npm nao encontrado ou falhou. Abortando.
+
+  exit /b 1
+
+)
+
+
+
+REM Install project dependencies
+
+echo Instalando dependencias...
+
+npm install
+
+
+
+REM Start Jobs service on port 3000
+
+echo Iniciando servico Jobs na porta 3000...
+
+npm run start -w services/jobs
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "apollo-talent-seeker",
+  "private": true,
+  "workspaces": ["apps/*", "services/*"],
+  "scripts": {
+    "test": "echo \"No tests\""
+  }
+}

--- a/services/candidates/Dockerfile
+++ b/services/candidates/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json .
+RUN npm install --production || true
+COPY . .
+CMD ["node", "dist/main.js"]

--- a/services/candidates/README.md
+++ b/services/candidates/README.md
@@ -1,0 +1,3 @@
+# Candidates Service
+
+Mantém dados de candidatos e deduplicação.

--- a/services/candidates/package.json
+++ b/services/candidates/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@services/candidates",
+  "version": "0.1.0",
+  "main": "dist/main.js",
+  "scripts": {
+    "start": "ts-node src/main.ts",
+    "build": "tsc -p tsconfig.json",
+    "test": "echo \"No tests\""
+  }
+}

--- a/services/candidates/src/main.ts
+++ b/services/candidates/src/main.ts
@@ -1,0 +1,1 @@
+console.log('Candidates service placeholder');

--- a/services/candidates/tsconfig.json
+++ b/services/candidates/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/services/files/Dockerfile
+++ b/services/files/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json .
+RUN npm install --production || true
+COPY . .
+CMD ["node", "dist/main.js"]

--- a/services/files/README.md
+++ b/services/files/README.md
@@ -1,0 +1,3 @@
+# Files Service
+
+Gerencia upload e conversão de arquivos.

--- a/services/files/package.json
+++ b/services/files/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@services/files",
+  "version": "0.1.0",
+  "main": "dist/main.js",
+  "scripts": {
+    "start": "ts-node src/main.ts",
+    "build": "tsc -p tsconfig.json",
+    "test": "echo \"No tests\""
+  }
+}

--- a/services/files/src/main.ts
+++ b/services/files/src/main.ts
@@ -1,0 +1,1 @@
+console.log('Files service placeholder');

--- a/services/files/tsconfig.json
+++ b/services/files/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/services/gateway/Dockerfile
+++ b/services/gateway/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json .
+RUN npm install --production || true
+COPY . .
+CMD ["node", "dist/main.js"]

--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -1,0 +1,3 @@
+# Gateway Service
+
+Responsável por autenticação e roteamento para os demais serviços.

--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@services/gateway",
+  "version": "0.1.0",
+  "main": "dist/main.js",
+  "scripts": {
+    "start": "ts-node src/main.ts",
+    "build": "tsc -p tsconfig.json",
+    "test": "echo \"No tests\""
+  }
+}

--- a/services/gateway/src/main.ts
+++ b/services/gateway/src/main.ts
@@ -1,0 +1,1 @@
+console.log('Gateway service placeholder');

--- a/services/gateway/tsconfig.json
+++ b/services/gateway/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/services/integrations-n8n/Dockerfile
+++ b/services/integrations-n8n/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json .
+RUN npm install --production || true
+COPY . .
+CMD ["node", "dist/main.js"]

--- a/services/integrations-n8n/README.md
+++ b/services/integrations-n8n/README.md
@@ -1,0 +1,3 @@
+# Integrations n8n Service
+
+Gerencia envio e recebimento de dados com o n8n.

--- a/services/integrations-n8n/package.json
+++ b/services/integrations-n8n/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@services/integrations-n8n",
+  "version": "0.1.0",
+  "main": "dist/main.js",
+  "scripts": {
+    "start": "ts-node src/main.ts",
+    "build": "tsc -p tsconfig.json",
+    "test": "echo \"No tests\""
+  }
+}

--- a/services/integrations-n8n/src/main.ts
+++ b/services/integrations-n8n/src/main.ts
@@ -1,0 +1,1 @@
+console.log('Integrations n8n service placeholder');

--- a/services/integrations-n8n/tsconfig.json
+++ b/services/integrations-n8n/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/services/jobs/Dockerfile
+++ b/services/jobs/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json .
+RUN npm install --production || true
+COPY . .
+CMD ["node", "dist/main.js"]

--- a/services/jobs/README.md
+++ b/services/jobs/README.md
@@ -1,0 +1,3 @@
+# Jobs Service
+
+Gerencia solicitações de vagas e regras de localidade.

--- a/services/jobs/package.json
+++ b/services/jobs/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@services/jobs",
+  "version": "0.1.0",
+  "main": "dist/main.js",
+  "scripts": {
+    "start": "ts-node src/main.ts",
+    "build": "tsc -p tsconfig.json",
+    "test": "echo \"No tests\""
+  }
+}

--- a/services/jobs/package.json
+++ b/services/jobs/package.json
@@ -6,5 +6,17 @@
     "start": "ts-node src/main.ts",
     "build": "tsc -p tsconfig.json",
     "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
+    "reflect-metadata": "^0.1.13",
+    "uuid": "^9.0.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.0"
   }
 }

--- a/services/jobs/src/app.module.ts
+++ b/services/jobs/src/app.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { JobsService } from './jobs/jobs.service';
+import { JobsController } from './jobs/jobs.controller';
+
+@Module({
+  controllers: [JobsController],
+  providers: [JobsService],
+})
+export class AppModule {}

--- a/services/jobs/src/jobs/dto/create-job.dto.ts
+++ b/services/jobs/src/jobs/dto/create-job.dto.ts
@@ -1,0 +1,32 @@
+import { IsArray, IsEnum, IsInt, IsString, Min } from 'class-validator';
+
+export enum JobMode {
+  PRESENCIAL = 'presencial',
+  REMOTO = 'remoto',
+  HIBRIDO = 'híbrido',
+}
+
+export class CreateJobDto {
+  @IsString()
+  title: string;
+
+  @IsEnum(JobMode)
+  mode: JobMode;
+
+  @IsString()
+  city: string;
+
+  @IsString()
+  state: string;
+
+  @IsString()
+  country: string;
+
+  @IsInt()
+  @Min(0)
+  minYearsExp: number;
+
+  @IsArray()
+  @IsString({ each: true })
+  requiredSkills: string[];
+}

--- a/services/jobs/src/jobs/entities/job.entity.ts
+++ b/services/jobs/src/jobs/entities/job.entity.ts
@@ -1,0 +1,12 @@
+import { JobMode } from '../dto/create-job.dto';
+
+export class Job {
+  id: string;
+  title: string;
+  mode: JobMode;
+  city: string;
+  state: string;
+  country: string;
+  minYearsExp: number;
+  requiredSkills: string[];
+}

--- a/services/jobs/src/jobs/jobs.controller.ts
+++ b/services/jobs/src/jobs/jobs.controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { JobsService } from './jobs.service';
+import { CreateJobDto } from './dto/create-job.dto';
+import { Job } from './entities/job.entity';
+
+@Controller('jobs')
+export class JobsController {
+  constructor(private readonly jobsService: JobsService) {}
+
+  @Post()
+  create(@Body() dto: CreateJobDto): Job {
+    return this.jobsService.create(dto);
+  }
+
+  @Get()
+  findAll(): Job[] {
+    return this.jobsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string): Job {
+    return this.jobsService.findOne(id);
+  }
+}

--- a/services/jobs/src/jobs/jobs.service.ts
+++ b/services/jobs/src/jobs/jobs.service.ts
@@ -1,0 +1,27 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { v4 as uuid } from 'uuid';
+import { Job } from './entities/job.entity';
+import { CreateJobDto } from './dto/create-job.dto';
+
+@Injectable()
+export class JobsService {
+  private jobs: Job[] = [];
+
+  create(dto: CreateJobDto): Job {
+    const job: Job = { id: uuid(), ...dto };
+    this.jobs.push(job);
+    return job;
+  }
+
+  findAll(): Job[] {
+    return this.jobs;
+  }
+
+  findOne(id: string): Job {
+    const job = this.jobs.find((j) => j.id === id);
+    if (!job) {
+      throw new NotFoundException('Job not found');
+    }
+    return job;
+  }
+}

--- a/services/jobs/src/main.ts
+++ b/services/jobs/src/main.ts
@@ -1,0 +1,1 @@
+console.log('Jobs service placeholder');

--- a/services/jobs/src/main.ts
+++ b/services/jobs/src/main.ts
@@ -1,1 +1,11 @@
-console.log('Jobs service placeholder');
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+  await app.listen(3000);
+}
+bootstrap();

--- a/services/jobs/tsconfig.json
+++ b/services/jobs/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/services/matching/Dockerfile
+++ b/services/matching/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json .
+RUN npm install --production || true
+COPY . .
+CMD ["node", "dist/main.js"]

--- a/services/matching/README.md
+++ b/services/matching/README.md
@@ -1,0 +1,3 @@
+# Matching Service
+
+Calcula percentuais de compatibilidade entre candidatos e vagas.

--- a/services/matching/package.json
+++ b/services/matching/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@services/matching",
+  "version": "0.1.0",
+  "main": "dist/main.js",
+  "scripts": {
+    "start": "ts-node src/main.ts",
+    "build": "tsc -p tsconfig.json",
+    "test": "echo \"No tests\""
+  }
+}

--- a/services/matching/src/main.ts
+++ b/services/matching/src/main.ts
@@ -1,0 +1,1 @@
+console.log('Matching service placeholder');

--- a/services/matching/tsconfig.json
+++ b/services/matching/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,8 @@
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {},
+    "test": {
+      "dependsOn": ["^test"],
+      "outputs": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold turborepo structure for services and admin UI
- add placeholder Dockerfiles and TypeScript configs for each service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b89ba2d1a083319940439d027fa027